### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Matthew Jones <mcolinj@mac.com>
 sentence=Detect a sequence of equally spaced pulses
 paragraph=Claps, drumbeats, stomps, or other impulse.
 url=https://github.com/mcolinj/Pulse-Detector.git
-category=Sensor
+category=Sensors
 includes=PulseDetector.h


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Sensor' in library PulseDetector is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format